### PR TITLE
Update assetgraph to version 7.0.1 (semver-minor)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "assetgraph": "^6.0.0",
+    "assetgraph": "^7.0.1",
     "optimist": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Since node 10 support has already been dropped the assetgraph switch won't affect this module :)